### PR TITLE
install pcregrep before use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To install NxFilter and the rc startup script:
 5. Run these commands, which downloads the install script from this Github repository and then executes it with sh:
 
   ```
-    curl -L -O 'https://raw.githubusercontent.com/DeepWoods/nxfilter-pfsense/master/install-nxfilter.sh' 
+    curl -L -O 'https://raw.githubusercontent.com/CitraIT/nxfilter-pfsense/master/install-nxfilter.sh' 
     sh install-nxfilter.sh
   ```
 

--- a/install-nxfilter.sh
+++ b/install-nxfilter.sh
@@ -100,6 +100,8 @@ echo "Installing required packages..."
 fetch ${FREEBSD_PACKAGE_LIST_URL}
 tar vfx packagesite.pkg
 
+pkg install -y pcre
+
 AddPkg () {
  	pkgname=$1
 	pkg unlock -yq $pkgname


### PR DESCRIPTION
Hi, 
i'm using this script to install NxFilter on OPNsense v24.x. 
It worked on older versions, but the script is failing at latest version where pcregrep executable is not found (not installed by default). 
