### PR TITLE
Fix compatibility with pfSense 2.8.1, OpenJDK 17 update, and rc.d fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,6 @@ Status
 
 The project provides an rc script to start and stop the NxFilter service and an installation script to automatically download and install everything, including the startup script.
 
-Compatibility
--------------
-
-The script is known to work on FreeBSD-based systems, including pfSense, OPNsense, FreeNAS, and more.
-
-> **Warning**This script *will destroy* a legacy BIOS system booting from an MBR formatted ZFS root volume; see [#168](https://github.com/unofficial-unifi/unifi-pfsense/issues/168). Again, using this script on a system with an MBR formatted ZFS root volume will break your system. It appears that one of the dependency packages may cause this. We have not isolated which. To avoid this problem, use UEFI mode if available, use GPT partitions, or use a filesystem other than ZFS.
-> 
-:bangbang:If you have already set up your system to use legacy BIOS, MBR partitons, and ZFS, then **do not run this script.**:bangbang:
-
 Challenges
 ----------
 
@@ -40,7 +31,6 @@ Upgrading
 ------------------
 
 At the very least, backup your configuration before proceeding.
-
 Be sure to track NxFilter's release notes for information on the changes and what to expect. Proceed with caution.
 
 Usage
@@ -55,7 +45,7 @@ To install NxFilter and the rc startup script:
 5. Run these commands, which downloads the install script from this Github repository and then executes it with sh:
 
   ```
-    curl -L -D 'https://raw.githubusercontent.com/leoescarpellin/nxfilter-pfsense/master/install-nxfilter.sh'
+    fetch 'https://raw.githubusercontent.com/leoescarpellin/nxfilter-pfsense/master/install-nxfilter.sh'
     sh install-nxfilter.sh
   ```
 
@@ -69,14 +59,14 @@ To start and stop NxFilter, use the `service` command from the command line.
 - To start NxFilter:
 
   ```
-    service nxfilter.sh start
+    service nxfilter start
   ```
   NxFilter takes a minute or two to start the web interface. The 'start' command exits immediately while the startup continues in the background.
 
 - To stop NxFilter:
 
   ```
-    service nxfilter.sh stop
+    service nxfilter stop
   ```
 
 Troubleshooting
@@ -123,21 +113,25 @@ Uninstalling therefore means one of two things:
 2. Remove the NxFilter software and rc script:
     ```
       rm -rf /usr/local/nxfilter
-      rm /usr/local/etc/rc.d/nxfilter.sh
+      rm /usr/local/etc/rc.d/nxfilter
     ```
 
 ### Removing the dependency packages
 
-To remove the packages that were installed by this script, you can go through the list of packages that were installed and remove them (look for the AddPkg lines). You will have to determine for yourself whether anything else on your system might still be using the packages installed by this script. Removing a package that is in use by something else will break that and other thing.
+To remove the packages installed by this script, you primarily need to uninstall the Java Runtime Environment.
 
-> **Note** that, on pfSense, all of them will probably be removed anyway the next time you update pfSense.
->
+**Warning:** Before running the commands below, ensure that no other packages on your system (e.g., UniFi Controller, Elasticsearch) rely on Java. Removing OpenJDK will break them.
+
+To remove the main Java package:
+
+```
+pkg delete openjdk17-jre
+```
 
 Contributing
 ------------
 
 By all means, feel free to contribute!  
-
 
 Licensing
 ---------

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To install NxFilter and the rc startup script:
 5. Run these commands, which downloads the install script from this Github repository and then executes it with sh:
 
   ```
-    fetch 'https://raw.githubusercontent.com/leoescarpellin/nxfilter-pfsense/master/install-nxfilter.sh'
+    fetch 'https://raw.githubusercontent.com/DeepWoods/nxfilter-pfsense/master/install-nxfilter.sh'
     sh install-nxfilter.sh
   ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To install NxFilter and the rc startup script:
 5. Run these commands, which downloads the install script from this Github repository and then executes it with sh:
 
   ```
-    curl -L -O 'https://raw.githubusercontent.com/DeepWoods/nxfilter-pfsense/master/install-nxfilter.sh' 
+    curl -L -D 'https://raw.githubusercontent.com/leoescarpellin/nxfilter-pfsense/master/install-nxfilter.sh'
     sh install-nxfilter.sh
   ```
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This script does three things:
 3. Install an rc script so that the NxFilter softward can be started and stopped with `service`
 
 Uninstalling therefore means one of two things:
-- Removing the NxFilter software at `/usr/local/nxfilter` and removing the rc script at `/usr/local/etc/rc.d/nxfilter.sh`
+- Removing the NxFilter software at `/usr/local/nxfilter` and removing the rc script at `/usr/local/etc/rc.d/nxfilter`
 - Removing the dependency packages that were installed
 
 ### Uninstall the NxFilter software

--- a/install-nxfilter.sh
+++ b/install-nxfilter.sh
@@ -41,7 +41,7 @@ if [ -f "$SERVICE_SCRIPT_PATH" ]; then
   PID=$(ps ax | grep "/usr/local/nxfilter/nxd.jar" | grep -v grep | awk '{ print $1 }')
   if [ ! -z "$PID" ]; then
     echo -n "Stopping the NxFilter service..."
-    /usr/sbin/service nxfilter.sh stop
+    /usr/sbin/service nxfilter stop
     echo " ok"
   fi
 fi
@@ -80,17 +80,17 @@ echo -n "Mounting new filesystems..."
 echo " ok"
 
 # Install OpenJDK JRE and dependencies:
-echo "Checking if openjdk8 is already installed..."
+echo "Checking if openjdk17 is already installed..."
 
-INSTALLED_VERSION=$(pkg info -x openjdk8-jre 2>/dev/null | awk '{print $1}' | cut -d'-' -f3)
-AVAILABLE_VERSION=$(pkg rquery '%v' openjdk8-jre 2>/dev/null)
+INSTALLED_VERSION=$(pkg info -x openjdk17-jre 2>/dev/null | awk '{print $1}' | cut -d'-' -f3)
+AVAILABLE_VERSION=$(pkg rquery '%v' openjdk17-jre 2>/dev/null)
 
 if [ "$INSTALLED_VERSION" = "$AVAILABLE_VERSION" ]; then
-  echo "openjdk8 version $INSTALLED_VERSION is already installed."
+  echo "openjdk17 version $INSTALLED_VERSION is already installed."
 else
-  echo "Installing openjdk8 version $AVAILABLE_VERSION..."
-  env ASSUME_ALWAYS_YES=YES pkg install -y openjdk8-jre || {
-    echo "Failed to install openjdk8. Aborting."
+  echo "Installing openjdk17 version $AVAILABLE_VERSION..."
+  env ASSUME_ALWAYS_YES=YES pkg install -y openjdk17-jre || {
+    echo "Failed to install openjdk17. Aborting."
     exit 1
   }
 fi
@@ -116,7 +116,7 @@ echo -n "Installing NxFilter in /usr/local/nxfilter..."
 echo " ok"
 
 # Create service script on rc.d
-echo -n "Creating nxfilter.sh service script in /usr/local/etc/rc.d/ ..."
+echo -n "Creating nxfilter service script in /usr/local/etc/rc.d/ ..."
 /bin/cat << "EOF" > $SERVICE_SCRIPT_PATH
 #!/bin/sh
 
@@ -224,5 +224,5 @@ if [ ! -z "${BACKUPFILE}" ] && [ -f ${BACKUPFILE} ]; then
 fi
 
 echo "Running the NxFilter service..."
-/usr/sbin/service nxfilter.sh start
+/usr/sbin/service nxfilter start
 echo "All done!"

--- a/install-nxfilter.sh
+++ b/install-nxfilter.sh
@@ -175,7 +175,7 @@ nxfilter_start()
     while [ "$x" -le 15 ];
     do
       # Procura pelo processo nxd.jar
-      PID=$(ps ax | grep 'nxd.jar' | grep -v grep | awk '{ print $1 }')
+      PID=$(ps axww | grep 'nxd.jar' | grep -v grep | awk '{ print $1 }')
       if [ ! -z "$PID" ]; then
         # Achou! Sai do loop
         break
@@ -187,7 +187,7 @@ nxfilter_start()
 
     # ### VALIDAÇÃO 2: Confere o resultado final ###
     # Verifica novamente se pegamos um PID válido
-    PID=$(ps ax | grep 'nxd.jar' | grep -v grep | awk '{ print $1 }')
+    PID=$(ps axww | grep 'nxd.jar' | grep -v grep | awk '{ print $1 }')
     
     if [ ! -z "$PID" ]; then
       echo "$PID" > $pidfile

--- a/install-nxfilter.sh
+++ b/install-nxfilter.sh
@@ -36,6 +36,9 @@ mv /tmp/pfSense.conf.tmp /usr/local/etc/pkg/repos/pfSense.conf
 
 env ASSUME_ALWAYS_YES=YES pkg update -f
 
+echo "Locking 'pkg' package to prevent system breakage..."
+env ASSUME_ALWAYS_YES=YES pkg lock -y pkg
+
 # Stop NxFilter if it's already running
 if [ -f "$SERVICE_SCRIPT_PATH" ]; then
   PID=$(ps ax | grep "/usr/local/nxfilter/nxd.jar" | grep -v grep | awk '{ print $1 }')
@@ -91,9 +94,14 @@ else
   echo "Installing openjdk17 version $AVAILABLE_VERSION..."
   env ASSUME_ALWAYS_YES=YES pkg install -y openjdk17-jre || {
     echo "Failed to install openjdk17. Aborting."
+    # Unlocking 'pkg' package
+    env ASSUME_ALWAYS_YES=YES pkg unlock -y pkg
     exit 1
   }
 fi
+
+# Unlocking 'pkg' package...
+env ASSUME_ALWAYS_YES=YES pkg unlock -y pkg
 
 # Restore original repos
 echo "Restoring original repos..."


### PR DESCRIPTION
Hi DeepWoods,

I've updated the script to fully support pfSense 2.8.1 (FreeBSD 15).

Summary of changes:

    Java Upgrade: Bumped dependency to OpenJDK 17 (JRE), as older versions are becoming deprecated on newer FreeBSD repos.

    Service Logic Fix: Updated the rc.d script to use ps axww. The previous command was cutting off the output, causing the service to report "FAILED" even when running successfully.

    Installation Improvements: More validations.
    
   Documentation: Cleaned up the README by removing unnecessary sections and updating instructions.

Please validate if these changes make sense to you. Thanks!